### PR TITLE
feat(examples): add readOnly and fullAccess examples for EksCluster 

### DIFF
--- a/README.md
+++ b/README.md
@@ -25,38 +25,6 @@ spec:
 EOF
 ```
 
-# phase1:
-```
-apiVersion: castai.upbound.io/v1alpha1
-kind: EksCluster
-metadata:
-  name: sample-cluster
-  labels:
-    cast-ai-cluster: sample
-spec:
-  forProvider:
-    accountId: "123456789101"
-    name: sample-cluster
-    region: eu-central-1
-```
-
-# phase2:
-```
-apiVersion: castai.upbound.io/v1alpha1
-kind: EksCluster
-metadata:
-  name: sample-cluster
-  labels:
-    cast-ai-cluster: sample
-spec:
-  forProvider:
-    accountId: "123456789101"
-    assumeRoleArn: arn:aws:iam::123456789101:role/cast-eks-sample-cluster-cluster-role
-    deleteNodesOnDisconnect: false
-    name: sample-cluster
-    region: eu-central-1
-```
-
 Notice that in this example Provider resource is referencing ControllerConfig with debug enabled.
 
 You can see the API reference [here](https://doc.crds.dev/github.com/dkb-bank/provider-castai).

--- a/examples/eksclusters/cluster_fullAccess.yaml
+++ b/examples/eksclusters/cluster_fullAccess.yaml
@@ -1,0 +1,13 @@
+apiVersion: castai.upbound.io/v1alpha1
+kind: EksCluster
+metadata:
+  name: sample
+  labels:
+    cast-ai-cluster: sample
+spec:
+  forProvider:
+    accountId: "123456789101"
+    name: sample
+    assumeRoleArn: arn:aws:iam::123456789101:role/cast-eks-sample-cluster-role
+    deleteNodesOnDisconnect: false
+    region: eu-central-1

--- a/examples/eksclusters/cluster_readOnly.yaml
+++ b/examples/eksclusters/cluster_readOnly.yaml
@@ -1,11 +1,12 @@
 apiVersion: castai.upbound.io/v1alpha1
 kind: EksCluster
 metadata:
-  name: sample
-  labels:
-    cast-ai-cluster: sample
+  name: sample-read-only
 spec:
   forProvider:
     accountId: "123456789101"
     name: sample
     region: eu-central-1
+  writeConnectionSecretToRef:
+    name: sample
+    namespace: crossplane-system


### PR DESCRIPTION
<!--
Thank you for helping to improve Crossplane!

Please read through https://git.io/fj2m9 if this is your first time opening a
Crossplane pull request. Find us in https://slack.crossplane.io/messages/dev if
you need any help contributing.
-->

### Description of your changes
add readOnly and fullAccess examples for EksCluster resource

<!--
Briefly describe what this pull request does. Be sure to direct your reviewers'
attention to anything that needs special consideration.

We love pull requests that resolve an open Crossplane issue. If yours does, you
can uncomment the below line to indicate which issue your PR fixes, for example
"Fixes #500":

-->
Fixes #

I have:

- [x] Read and followed Crossplane's [contribution process].
- [x] Run `make reviewable test` to ensure this PR is ready for review.

### How has this code been tested

```
kubectl describe ekscluster.castai.upbound.io/sample
Name:         sample
Namespace:    
Labels:       cast-ai-cluster=sample
Annotations:  crossplane.io/external-create-pending: 2023-06-22T20:05:53+02:00
              crossplane.io/external-create-succeeded: 2023-06-22T20:05:53+02:00
              crossplane.io/external-name: f46c8081-70df-4081-b274-2c69b8f393a1
              upjet.crossplane.io/provider-meta:
                {"e2bfb730-ecaa-11e6-8f88-34363bc7c4c0":{"create":300000000000,"delete":300000000000,"update":60000000000}}
API Version:  castai.upbound.io/v1alpha1
Kind:         EksCluster
Metadata:
  Creation Timestamp:  2023-06-22T18:05:48Z
  Finalizers:
    finalizer.managedresource.crossplane.io
  Generation:        1
  Resource Version:  1654010
  UID:               b815157d-930c-4d85-a827-1125035c4c67
Spec:
  Deletion Policy:  Delete
  For Provider:
    Account Id:       123456789101
    Name:             sample
    Region:           eu-central-1
  Management Policy:  FullControl
  Provider Config Ref:
    Name:  default
  Write Connection Secret To Ref:
    Name:       sample
    Namespace:  crossplane-system
Status:
  At Provider:
    Account Id:       123456789101
    Assume Role Arn:  
    Credentials Id:   
    Id:               f46c8081-70df-4081-b274-2c69b8f393a1
    Name:             sample
    Region:           eu-central-1
  Conditions:
    Last Transition Time:  2023-06-22T18:05:55Z
    Reason:                Available
    Status:                True
    Type:                  Ready
    Last Transition Time:  2023-06-22T18:05:53Z
    Reason:                ReconcileSuccess
    Status:                True
    Type:                  Synced
    Last Transition Time:  2023-06-22T18:05:54Z
    Reason:                Finished
    Status:                True
    Type:                  AsyncOperation
    Last Transition Time:  2023-06-22T18:05:54Z
    Reason:                Success
    Status:                True
    Type:                  LastAsyncOperation
Events:
  Type    Reason                   Age   From                                                 Message
  ----    ------                   ----  ----                                                 -------
  Normal  CreatedExternalResource  3s    managed/castai.upbound.io/v1alpha1, kind=ekscluster  Successfully requested creation of external resource
```

```
kubectl get secrets sample -n crossplane-system -o yaml
apiVersion: v1
data:
  attribute.cluster_token: abcd==
kind: Secret
metadata:
  creationTimestamp: "2023-06-22T18:05:53Z"
  name: sample
  namespace: crossplane-system
  ownerReferences:
  - apiVersion: castai.upbound.io/v1alpha1
    blockOwnerDeletion: true
    controller: true
    kind: EksCluster
    name: sample
    uid: b815157d-930c-4d85-a827-1125035c4c67
  resourceVersion: "1654008"
  uid: 551f5b42-f701-4215-8e72-7d4dce2cb307
type: connection.crossplane.io/v1alpha1
```


<!--
Before reviewers can be confident in the correctness of this pull request, it
needs to tested and shown to be correct. Briefly describe the testing that has
already been done or which is planned for this change.
-->

[contribution process]: https://git.io/fj2m9
